### PR TITLE
fix: add optional chaining on format prop

### DIFF
--- a/packages/astronotion/src/api/lib/get-cover.ts
+++ b/packages/astronotion/src/api/lib/get-cover.ts
@@ -28,7 +28,7 @@ export const getCover = (
 			url: data.cover,
 			position,
 		};
-	} else if ("type" in data && data.type === "page" && !!data.format.page_cover) {
+	} else if ("type" in data && data.type === "page" && !!data.format?.page_cover) {
 		const position = data.format.page_cover_position ?? undefined;
 		return {
 			url: data.format.page_cover,

--- a/packages/astronotion/src/api/lib/transform-page.ts
+++ b/packages/astronotion/src/api/lib/transform-page.ts
@@ -57,7 +57,7 @@ const getDownloadableUrlsFromPage = (data: ExtendedRecordMap) => {
 const transformChildPageBlock = (data: PageBlock, downloadableUrls?: string[]) => {
 	const { id, properties, format, created_time, last_edited_time } = data;
 	const title = flattenText(properties?.title || []);
-	const icon = format.page_icon;
+	const icon = format?.page_icon;
 
 	const cover = getCover(data);
 	if (cover && cover.url) {
@@ -132,7 +132,7 @@ export const transformEntryPage = (data: ExtendedRecordMap): AnEntryPage | undef
 
 	const { id, properties, format, created_time, last_edited_time } = pageBlock;
 	const title = flattenText(properties.title);
-	const icon = format.page_icon;
+	const icon = format?.page_icon;
 
 	const cover = getCover(pageBlock);
 	if (cover && cover.url) {


### PR DESCRIPTION
Closes #2 

A block object's `format` property could be undefined, contrary to notion-types definition: https://github.com/NotionX/react-notion-x/blob/master/packages/notion-types/src/block.ts#L149-L158